### PR TITLE
Tweaked some settings to match real aircraft

### DIFF
--- a/PFS757/PackageSources/SimObjects/Airplanes/MyCompany_Simple_Aircraft/aircraft.cfg
+++ b/PFS757/PackageSources/SimObjects/Airplanes/MyCompany_Simple_Aircraft/aircraft.cfg
@@ -12,8 +12,8 @@ wip_indicator = 2
 icao_type_designator ="AIRCRAFT"
 icao_manufacturer ="BOEING"
 icao_model ="B752"
-icao_engine_type ="Piston"
-icao_engine_count =1
+icao_engine_type ="Jet"
+icao_engine_count =2
 icao_WTC ="M"
 icao_generic=0
 

--- a/PFS757/PackageSources/SimObjects/Airplanes/MyCompany_Simple_Aircraft/engines.cfg
+++ b/PFS757/PackageSources/SimObjects/Airplanes/MyCompany_Simple_Aircraft/engines.cfg
@@ -5,9 +5,9 @@ minor =0
 [GENERALENGINEDATA]
 engine_type =1
 fuel_flow_scalar =0.7632
-min_throttle_limit =0.02
+min_throttle_limit =-0.2
 master_ignition_switch =0
-starter_type =0
+starter_type =2
 max_contrail_temperature =-39.724
 Engine.0 = 21.44393, -21.180962, -14.46409
 ThrustAnglesPitchHeading.0 = 0, 0
@@ -21,7 +21,7 @@ ThrustAnglesPitchHeading.1= 0, 0
 DisableFuelValveControls=0
 DisableMixtureControls=0
 DisableParkingBrakeControls=0
-DisablePropellerControls=0
+DisablePropellerControls=1
 DisableAutopilotControls=0
 [TURBINEENGINEDATA]
 fuel_flow_gain=0.002

--- a/PFS757/PackageSources/SimObjects/Airplanes/MyCompany_Simple_Aircraft/flight_model.cfg
+++ b/PFS757/PackageSources/SimObjects/Airplanes/MyCompany_Simple_Aircraft/flight_model.cfg
@@ -3,8 +3,8 @@ major =1
 minor =0
 
 [WEIGHT_AND_BALANCE]
-max_gross_weight =220000
-empty_weight =130440
+max_gross_weight =255000
+empty_weight =128840
 reference_datum_position = 0, 0, 22.046982
 empty_weight_CG_position = 0, 0, -7.65583
 CG_forward_limit =17.8


### PR DESCRIPTION
Here is what I changed:

- aircraft.cfg:
    - Changed engine type to Jet
    - Changed engine count to 2

- engines.cfg
    - Lowered min throttle limit to -0.2 for reversers to work properly
    - Changed starter type to bleed air
    - Disabled propeller controls

- flight_model.cfg
    - Adjusted empty weight and max gross weight to match the real aircraft


Let me know if anything is wrong, thanks ;)